### PR TITLE
fix/tweak various display items

### DIFF
--- a/src/Components/JoinGroup/JoinGroup.js
+++ b/src/Components/JoinGroup/JoinGroup.js
@@ -112,7 +112,7 @@ export class JoinGroup extends Component {
       });
     } else {
       this.setState({
-        message: <h5>Failed to join group... please try again</h5>
+        message: <h5>Failed to join group.  Please try again.</h5>
       });
     }
   }
@@ -131,7 +131,11 @@ export class JoinGroup extends Component {
     this.props.updateGroupTransactions(groupTransactions);
 
     this.setState({
-      message: <h5>You successfully joined {groupData.group_name}! Click <Link to="/group">here</Link> to visit your group page or <Link to="/user">here</Link> to visit your user page.</h5>,
+      message: 
+        <div>
+          <h5>You successfully joined {groupData.group_name}!</h5>
+          <h5>You should check out your <Link to="/group">group page</Link> or <Link to="/user">user page.</Link></h5>
+        </div>,
       hideintro: true
     });
   }

--- a/src/Components/JoinGroup/JoinGroup.scss
+++ b/src/Components/JoinGroup/JoinGroup.scss
@@ -21,13 +21,17 @@
 
     a {
       font-size: 24px;
-      color: $c3;
+      color: $c1;
       font-weight: 900;
       position: relative;
-      top: 9px;
+    }
+
+    a:hover {
+      color: darken($c1, 12%);
     }
 
     h5 {
+      line-height: 1.3;
       color: $c3;
       font-weight: 900;
     }
@@ -45,9 +49,10 @@
       text-align: center;
       width: 220px;
       margin-left: 15px;
-      height: 60px;
       border-bottom: 8px solid $c4;
       background-color: $c5;
+      padding: 7px 0 13px;
+      overflow-wrap: break-word;
     }
   }
 

--- a/src/Components/LeaderboardDisplay/LeaderboardDisplay.js
+++ b/src/Components/LeaderboardDisplay/LeaderboardDisplay.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import './LeaderboardDisplay.css';
 
 const LeaderboardDisplay = ({ name, points, position }) => {
-  console.log(name, points, position)
   return (
     <div className="leaderboard-display-component">
       <h5 className="leaderboard-position">{position}.</h5>

--- a/src/Components/Slack/Slack.js
+++ b/src/Components/Slack/Slack.js
@@ -59,7 +59,7 @@ class Slack extends Component {
         <div className="slack-header">
           <h4>CONNECT TO SLACK</h4>
         </div>
-        <h5>Type /snap anywhere in Slack to get your User Id! (case sensitive)</h5>
+        <h5>Type <span>/snap</span> anywhere in Slack to get your User Id. (case sensitive)</h5>
         <input 
           type="text" 
           value={this.state.slackId} 

--- a/src/Components/Slack/Slack.scss
+++ b/src/Components/Slack/Slack.scss
@@ -20,7 +20,10 @@
   }
 
   h5 {
+    color: $c3;
+    font-weight: 900;
     margin: 30px 0px;
+    line-height: 1.3;
   }
 
 	input, button {


### PR DESCRIPTION
change language and line heights in in-app slack messaging
allow boxes to grow in height in case of extra long group names